### PR TITLE
カプセル化

### DIFF
--- a/encapsulation/TriangleFigure.php
+++ b/encapsulation/TriangleFigure.php
@@ -1,0 +1,35 @@
+<?php
+
+class TriangleFigure {
+    private $base;
+    private $height;
+    
+    public function __construct() {
+	$this->base   = 1;
+	$this->height = 1;
+    }
+    
+    public function getBase() {
+	return $this->base;
+    }
+    
+    public function setBase($base) {
+	if (is_numeric($base) && $base > 0) {
+	    $this->base = $base;
+	}
+    }
+    
+    public function getHeight() {
+	return $this->height;
+    }
+    
+    public function setHeight($height) {
+	if (is_numeric($height) && $height > 0) {
+	    $this->height = $height;
+	}
+    }
+    
+    public function getArea() {
+	return $this->getBase() * $this->getArea() / 2;
+    }
+}

--- a/encapsulation/accessor.php
+++ b/encapsulation/accessor.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once 'TriangleFigure.php';
+
+$tri = new TriangleFigure();
+
+$tir->setBase(-10);
+$tir->setHeight('hogehoge');
+
+print '三角形の面積：{$tri->getArea()}';


### PR DESCRIPTION
・アクセサメソッド
　・カプセル化の典型的な例として、プロパティを隠蔽して、メソッドから隠蔽されたプロパティにアクセスをする。
・不要な機能を隠す役割を担うのは、アクセス修飾子
　・public
　・private
　・protected